### PR TITLE
Add quotes around ArgumentList to avoid PowerShell error

### DIFF
--- a/bootstrap.ps1
+++ b/bootstrap.ps1
@@ -118,11 +118,11 @@ function InstallOrUpdate-Bundles {
     Write-Output "Calling Vundle's :BundleInstall!"
     try {
         # Try to find gvim.exe in $env:Path or in App Paths
-        Start-Process gvim -ArgumentList -u,$loader_file_path,+BundleInstall!,+qall
+        Start-Process gvim -ArgumentList "-u,$loader_file_path,+BundleInstall!,+qall"
     } catch {
         try {
             # Failing that, try to locate it manually
-            Start-Process (Get-GvimExePath) -ArgumentList -u,$loader_file_path,+BundleInstall!,+qall
+            Start-Process (Get-GvimExePath) -ArgumentList "-u,$loader_file_path,+BundleInstall!,+qall"
         } catch {
             throw "Unable to locate gvim.exe"
         }


### PR DESCRIPTION
PowerShell chokes with a "Missing argument in parameter list" error on Windows Server 2012 R2 Standard without quotes around the arguments given to ArgumentList.

I have also tested with and without this fix on a Windows 8.1 system, with the same results: without the fix I get "Missing argument in parameter list", and this error disappears after the fix is applied.
